### PR TITLE
fix: vendor field in transactions

### DIFF
--- a/.github/workflows/notarization-functional.yml
+++ b/.github/workflows/notarization-functional.yml
@@ -125,3 +125,42 @@ jobs:
               run: |
                   cd packages/notarization-transactions
                   yarn test __tests__/functional/transaction-forging/notarization/multi-signature.test.ts --forceExit
+
+    functional-notarization-transactions-vendor-field:
+        name: NOTARIZATION-VENDOR-FIELD
+        runs-on: ubuntu-latest
+        services:
+            postgres:
+                image: postgres:12
+                env:
+                    POSTGRES_USER: ark
+                    POSTGRES_PASSWORD: password
+                    POSTGRES_DB: ark_unitnet
+                ports:
+                    - 5432:5432
+                options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+        strategy:
+            matrix:
+                node-version: [ 12.x ]
+        env:
+            CORE_DB_DATABASE: ark_unitnet
+            CORE_DB_USERNAME: ark
+            POSTGRES_USER: ark
+            POSTGRES_PASSWORD: password
+            POSTGRES_DB: ark_unitnet
+
+        steps:
+            - uses: actions/checkout@v2
+            - name: Use Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v2
+              with:
+                  node-version: ${{ matrix.node-version }}
+
+            - name: Install and build packages
+              run: yarn && yarn build
+
+            - name: TEST
+              run: |
+                  cd packages/notarization-transactions
+                  yarn test __tests__/functional/transaction-forging/notarization/vendor-field.test.ts --forceExit

--- a/packages/notarization-crypto/src/builders/notarization.ts
+++ b/packages/notarization-crypto/src/builders/notarization.ts
@@ -27,6 +27,8 @@ export class NotarizationBuilder extends Transactions.TransactionBuilder<Notariz
         const struct: Interfaces.ITransactionData = super.getStruct();
         struct.amount = this.data.amount;
         struct.asset = this.data.asset;
+        struct.vendorField = this.data.vendorField;
+
         return struct;
     }
 

--- a/packages/notarization-transactions/__tests__/functional/transaction-forging/__support__/index.ts
+++ b/packages/notarization-transactions/__tests__/functional/transaction-forging/__support__/index.ts
@@ -41,6 +41,7 @@ export const setUp = async (): Promise<Contracts.Kernel.Application> => {
 
         Managers.configManager.getMilestone().aip11 = true;
         Managers.configManager.getMilestone().htlcEnabled = true;
+        Managers.configManager.getMilestone().vendorFieldLength = 255;
 
         const databaseService = app.get<DatabaseService>(Container.Identifiers.DatabaseService);
         const walletRepository = app.getTagged<Contracts.State.WalletRepository>(

--- a/packages/notarization-transactions/__tests__/functional/transaction-forging/__support__/transaction-factory.ts
+++ b/packages/notarization-transactions/__tests__/functional/transaction-forging/__support__/transaction-factory.ts
@@ -11,6 +11,12 @@ export class NotarizationTransactionFactory extends TransactionFactory {
         return new NotarizationTransactionFactory(app);
     }
 
+    public withVendorField(vendorField: string): NotarizationTransactionFactory {
+        this.builder.vendorField(vendorField);
+
+        return this;
+    }
+
     public Notarization(notarization: Interfaces.INotarizationAsset): NotarizationTransactionFactory {
         this.builder = new Builders.NotarizationBuilder().Notarization(notarization);
 

--- a/packages/notarization-transactions/__tests__/functional/transaction-forging/notarization/vendor-field.test.ts
+++ b/packages/notarization-transactions/__tests__/functional/transaction-forging/notarization/vendor-field.test.ts
@@ -1,0 +1,30 @@
+import "@arkecosystem/core-test-framework/dist/matchers";
+
+import { Contracts } from "@arkecosystem/core-kernel";
+import { passphrases, snoozeForBlock } from "@arkecosystem/core-test-framework";
+
+import * as support from "../__support__";
+import { NotarizationTransactionFactory } from "../__support__/transaction-factory";
+
+const notarizationAsset = {
+    hash: "hash",
+};
+
+let app: Contracts.Kernel.Application;
+beforeAll(async () => (app = await support.setUp()));
+afterAll(async () => await support.tearDown());
+
+describe("Notarization functional tests - with VendorField", () => {
+    it("should broadcast, accept and forge it [Signed with 1 Passphrase]", async () => {
+        // Save notarization
+        const notarization = NotarizationTransactionFactory.initialize(app)
+            .Notarization(notarizationAsset)
+            .withVendorField("VendorField test -> [Notarization]")
+            .withPassphrase(passphrases[0]!)
+            .createOne();
+
+        await expect(notarization).toBeAccepted();
+        await snoozeForBlock(1);
+        await expect(notarization.id).toBeForged();
+    });
+});


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Fixed building of transactions with vendorField.

### What changes are being made?
- Added vendorField property in `getStruct`
- Adjusted `transaction-forging` setup
- Added vendorField specific functional tests
- Added specific GitHub Actions for this type of tests

### Why are these changes necessary?
We decided that we will support vendorField in this custom transactions, so we set `setVendorField to true`.
We forgot to set vendorField property in `getStruct` method.

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->

